### PR TITLE
fifo/gk104: fix chid bit mask

### DIFF
--- a/drm/nouveau/nvkm/engine/fifo/gk104.c
+++ b/drm/nouveau/nvkm/engine/fifo/gk104.c
@@ -198,11 +198,11 @@ gk104_fifo_intr_sched_ctxsw(struct gk104_fifo *fifo)
 	for (engn = 0; engn < ARRAY_SIZE(fifo->engine); engn++) {
 		u32 stat = nvkm_rd32(device, 0x002640 + (engn * 0x08));
 		u32 busy = (stat & 0x80000000);
-		u32 next = (stat & 0x07ff0000) >> 16;
+		u32 next = (stat & 0x0fff0000) >> 16;
 		u32 chsw = (stat & 0x00008000);
 		u32 save = (stat & 0x00004000);
 		u32 load = (stat & 0x00002000);
-		u32 prev = (stat & 0x000007ff);
+		u32 prev = (stat & 0x00000fff);
 		u32 chid = load ? next : prev;
 		(void)save;
 

--- a/drm/nouveau/nvkm/engine/gr/ctxgk20a.c
+++ b/drm/nouveau/nvkm/engine/gr/ctxgk20a.c
@@ -34,7 +34,7 @@ gk20a_grctx_generate_main(struct gf100_gr *gr, struct gf100_grctx *info)
 
 	gf100_gr_mmio(gr, gr->fuc_sw_ctx);
 
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	idle_timeout_save = nvkm_rd32(device, 0x404154);
 	nvkm_wr32(device, 0x404154, 0x00000000);
@@ -57,13 +57,13 @@ gk20a_grctx_generate_main(struct gf100_gr *gr, struct gf100_grctx *info)
 
 	nvkm_mask(device, 0x5044b0, 0x08000000, 0x08000000);
 
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	nvkm_wr32(device, 0x404154, idle_timeout_save);
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	gf100_gr_mthd(gr, gr->fuc_method);
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	gf100_gr_icmd(gr, gr->fuc_bundle);
 	grctx->pagepool(info);

--- a/drm/nouveau/nvkm/engine/gr/ctxgm20b.c
+++ b/drm/nouveau/nvkm/engine/gr/ctxgm20b.c
@@ -45,7 +45,7 @@ gm20b_grctx_generate_main(struct gf100_gr *gr, struct gf100_grctx *info)
 
 	gf100_gr_mmio(gr, gr->fuc_sw_ctx);
 
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	idle_timeout_save = nvkm_rd32(device, 0x404154);
 	nvkm_wr32(device, 0x404154, 0x00000000);
@@ -72,13 +72,13 @@ gm20b_grctx_generate_main(struct gf100_gr *gr, struct gf100_grctx *info)
 
 	gm204_grctx_generate_405b60(gr);
 
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	nvkm_wr32(device, 0x404154, idle_timeout_save);
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	gf100_gr_mthd(gr, gr->fuc_method);
-	gf100_gr_wait_idle(gr);
+	gk104_gr_wait_idle(gr);
 
 	gf100_gr_icmd(gr, gr->fuc_bundle);
 	grctx->pagepool(info);

--- a/drm/nouveau/nvkm/engine/gr/gf100.c
+++ b/drm/nouveau/nvkm/engine/gr/gf100.c
@@ -702,40 +702,6 @@ gf100_gr_zbc_init(struct gf100_gr *gr)
 		gf100_gr_zbc_clear_depth(gr, index);
 }
 
-/**
- * Wait until GR goes idle. GR is considered idle if it is disabled by the
- * MC (0x200) register, or GR is not busy and a context switch is not in
- * progress.
- */
-int
-gf100_gr_wait_idle(struct gf100_gr *gr)
-{
-	struct nvkm_subdev *subdev = &gr->base.engine.subdev;
-	struct nvkm_device *device = subdev->device;
-	unsigned long end_jiffies = jiffies + msecs_to_jiffies(2000);
-	bool gr_enabled, ctxsw_active, gr_busy;
-
-	do {
-		/*
-		 * required to make sure FIFO_ENGINE_STATUS (0x2640) is
-		 * up-to-date
-		 */
-		nvkm_rd32(device, 0x400700);
-
-		gr_enabled = nvkm_rd32(device, 0x200) & 0x1000;
-		ctxsw_active = nvkm_rd32(device, 0x2640) & 0x8000;
-		gr_busy = nvkm_rd32(device, 0x40060c) & 0x1;
-
-		if (!gr_enabled || (!gr_busy && !ctxsw_active))
-			return 0;
-	} while (time_before(jiffies, end_jiffies));
-
-	nvkm_error(subdev,
-		   "wait for idle timeout (en: %d, ctxsw: %d, busy: %d)\n",
-		   gr_enabled, ctxsw_active, gr_busy);
-	return -EAGAIN;
-}
-
 void
 gf100_gr_mmio(struct gf100_gr *gr, const struct gf100_gr_pack *p)
 {

--- a/drm/nouveau/nvkm/engine/gr/gf100.h
+++ b/drm/nouveau/nvkm/engine/gr/gf100.h
@@ -198,11 +198,12 @@ extern struct gf100_gr_ucode gf100_gr_gpccs_ucode;
 extern struct gf100_gr_ucode gk110_gr_fecs_ucode;
 extern struct gf100_gr_ucode gk110_gr_gpccs_ucode;
 
-int  gf100_gr_wait_idle(struct gf100_gr *);
 void gf100_gr_mmio(struct gf100_gr *, const struct gf100_gr_pack *);
 void gf100_gr_icmd(struct gf100_gr *, const struct gf100_gr_pack *);
 void gf100_gr_mthd(struct gf100_gr *, const struct gf100_gr_pack *);
 int  gf100_gr_init_ctxctl(struct gf100_gr *);
+
+int  gk104_gr_wait_idle(struct gf100_gr *);
 
 /* register init value lists */
 

--- a/drm/nouveau/nvkm/engine/gr/gk20a.c
+++ b/drm/nouveau/nvkm/engine/gr/gk20a.c
@@ -198,7 +198,7 @@ gk20a_gr_init(struct gf100_gr *gr)
 	if (ret)
 		return ret;
 
-	ret = gf100_gr_wait_idle(gr);
+	ret = gk104_gr_wait_idle(gr);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
gr: rename gf100_gr_wait_idle for gk104_\* …
The status bit used in gf100_gr_wait_idle only exists starting gk104.
As the function is currently used in gk20a and later, rename the function
to use gk104 prefix to reflex correct supported chip version.

Signed-off-by: Xia Yang xiay@nvidia.com

Fix the channel id bit mask in FIFO schedule timeout error handling.

FIFO_ENGINE_STATUS_NEXT_ID is bit 27:16 thus 0x0fff0000.
FIFO_ENGINE_STATUS_ID      is bit 11:0  thus 0x00000fff.

Signed-off-by: Xia Yang xiay@nvidia.com
